### PR TITLE
Use native AES-XTS in hacbrewpack

### DIFF
--- a/.changeset/native-aes-xts.md
+++ b/.changeset/native-aes-xts.md
@@ -1,0 +1,5 @@
+---
+"@tootallnate/hacbrewpack": patch
+---
+
+Use native AES-XTS encryption when available to speed up NCA header generation on nx.js.

--- a/packages/hacbrewpack/src/index.ts
+++ b/packages/hacbrewpack/src/index.ts
@@ -189,6 +189,34 @@ async function mapToUint8Arrays(
 	return result;
 }
 
+async function createNativeAesXtsEncrypt(
+	headerKey: Uint8Array,
+	crypto: Crypto
+): Promise<AesXtsEncryptFn | undefined> {
+	try {
+		const key = await crypto.subtle.importKey(
+			'raw',
+			headerKey,
+			'AES-XTS' as AlgorithmIdentifier,
+			false,
+			['encrypt']
+		);
+		return (data, sectorSize, startSector) =>
+			crypto.subtle.encrypt(
+				{
+					name: 'AES-XTS',
+					sectorSize,
+					sector: startSector,
+					isNintendo: true,
+				} as AlgorithmIdentifier,
+				key,
+				data
+			);
+	} catch {
+		return undefined;
+	}
+}
+
 /**
  * Build an NSP (Nintendo Submission Package) from input files.
  *
@@ -228,6 +256,8 @@ export async function buildNsp(
 	} else {
 		keys = options.keys;
 	}
+	const effectiveAesXtsEncrypt =
+		aesXtsEncrypt ?? (await createNativeAesXtsEncrypt(keys.headerKey, crypto));
 
 	// Convert input files to Uint8Arrays
 	const exefsMap = await mapToUint8Arrays(options.exefs);
@@ -333,7 +363,7 @@ export async function buildNsp(
 		plaintext,
 		keys,
 		crypto,
-		aesXtsEncrypt,
+		aesXtsEncrypt: effectiveAesXtsEncrypt,
 	};
 
 	const programNca = await createProgramNca({

--- a/packages/nca/src/index.ts
+++ b/packages/nca/src/index.ts
@@ -101,7 +101,7 @@ import {
  * );
  * const aesXtsEncrypt: AesXtsEncryptFn = (data, sectorSize, startSector) =>
  *   crypto.subtle.encrypt(
- *     { name: 'AES-XTS', sectorSize, startSector, nintendoTweak: true },
+ *     { name: 'AES-XTS', sectorSize, sector: startSector, isNintendo: true },
  *     cryptoKey,
  *     data
  *   );


### PR DESCRIPTION
## Summary

- Detect native `AES-XTS` support and use it for NCA header encryption when available.
- Pass nx.js-compatible Nintendo XTS options (`sector`, `isNintendo`) to the native WebCrypto implementation.
- Correct the AES-XTS example in `@tootallnate/nca` docs.

## Verification

- `pnpm --filter @tootallnate/aes-xts build`
- `pnpm --filter @tootallnate/ivfc build`
- `pnpm --filter @tootallnate/lz4 build`
- `pnpm --filter @tootallnate/romfs build`
- `pnpm --filter @tootallnate/cnmt build`
- `pnpm --filter @tootallnate/nca build`
- `pnpm --filter @tootallnate/hacbrewpack build`
- On-device applet-mode install succeeded using native AES-XTS (`Daybreak` forwarder, ~4.4s)