### PR TITLE
fix(pfs0): add .js extensions to relative imports for Node ESM

### DIFF
--- a/.changeset/pfs0-esm-extensions.md
+++ b/.changeset/pfs0-esm-extensions.md
@@ -1,0 +1,5 @@
+---
+'@tootallnate/pfs0': patch
+---
+
+Fix ESM resolution under Node: the emitted `dist/index.js` imported `./types` without a `.js` extension, which Node's ESM loader rejects with `ERR_MODULE_NOT_FOUND`. The source relative imports now include the explicit `.js` extension so the published package imports cleanly in Node.

--- a/packages/pfs0/src/index.ts
+++ b/packages/pfs0/src/index.ts
@@ -2,9 +2,9 @@
  * Reference: https://switchbrew.org/wiki/NCA#PFS0
  */
 import { decodeCString } from '@nx.js/util';
-import { Pfs0FileTable, Pfs0Header } from './types';
+import { Pfs0FileTable, Pfs0Header } from './types.js';
 
-export * from './types';
+export * from './types.js';
 
 export async function decode(data: Blob): Promise<Map<string, Blob>> {
 	const { magic, totalFiles, stringTableSize } = new Pfs0Header(


### PR DESCRIPTION
## Summary
- `@tootallnate/pfs0` is `"type": "module"`, but its emitted `dist/index.js` imported `./types` without a `.js` extension. Node's ESM loader requires explicit extensions, so importing the published package throws `ERR_MODULE_NOT_FOUND`.
- Add explicit `.js` extensions to the relative imports in `src/index.ts` so the emitted dist resolves cleanly under Node ESM.

## Why
Hit while consuming `@tootallnate/pfs0` from a plain Node script (sys-autopilot's NSZ installer). `ncz`/`zstd-wasm` are unaffected because they have no relative imports; `pfs0` is the only package importing a sibling module.

## Verification
- `node -e "import('@tootallnate/pfs0')"` now resolves (`decode`/`encode` exported) instead of throwing.
- Changeset included (patch).